### PR TITLE
Revert "README提出前の修正　馬場"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Things you may want to cover:
 |rating|string||
 
 ### Association
+- has_many :items
 - has_many :users
-- has_many :rate_counts
+
 
 ## rate_countsテーブル
 
@@ -73,12 +74,13 @@ Things you may want to cover:
 |id|||
 |rating_id|reference|foreign_key: true|
 |user_id|reference|foreign_key: true|
-|order_id|reference|foreign_key: true|
+|item_id|reference|foreign_key: true|
 |message|text||
 
+
 ### Association
+- has_many :items
 - has_many :users
-- has_many :orders
 
 
 ## prefecturesテーブル
@@ -94,13 +96,27 @@ Things you may want to cover:
 
 
 ## pointsテーブル
+
 |Column|Type|Options|
 |------|----|-------|
 |id|||
 |amount|integer||
+|user_id|reference|foreign_key: true|
+|point_limit_id|reference|foreign_key: true|
 
 ### Association
 - belongs_to :user
+
+
+## point_limitテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|id|||
+|point_limit|string||
+
+### Association
+- has_many :points
 
 
 ## profitsテーブル
@@ -108,7 +124,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |id|||
-|profit|integer||
+|prpfit|integer||
 |user_id|reference|foreign_key: true|
 |item_id|reference|foreign_key: true|
 |trade_end_date|daytime||
@@ -126,12 +142,14 @@ Things you may want to cover:
 |message|text||
 |user_id|reference|foreign_key: true|
 |item_id|reference|foreign_key: true|
+|seller|boolean||
 |order_status_id|reference|foreign_key: true|
 
 ### Association
 - belongs_to :item
 - belongs_to :user
 - belongs_to :order_status
+
 
 ## likesテーブル
 
@@ -146,6 +164,17 @@ Things you may want to cover:
 - belongs_to :user
 
 
+## flagsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|id|||
+|user_id|reference|foreign_key: true|
+
+### Association
+- belongs_to :item
+- belongs_to :user
+
 ## itemsテーブル
 
 |Column|Type|Options|
@@ -155,11 +184,11 @@ Things you may want to cover:
 |name|string|null:false|
 |price|integer|null:false|
 |description|text|null:false|
-|first_category_id|reference|foreign_key:true|p
+|category1_id|reference|foreign_key:true|
 |brand_id|reference|foreign_key:true|
 |size_id|reference|foreign_key:true|
 |condition_id|reference|foreign_key:true|
-|delivery_charge_id|reference|foreign_key:true|
+|delivery_charge|reference|foreign_key:true|
 |prefecure_id|reference|foreign_key:true|
 |delivery_dates_id|reference|foreign_key:true|
 |order_status_id|reference|foreign_key:true|
@@ -168,8 +197,10 @@ Things you may want to cover:
 - has_many :item_images
 - has_many :messages
 - has_many :likes
+- has_many :flags
 - has_many :message_users,through::messages,source::user
 - has_many :like_users,through::likes,source::user
+- has_many :flag_users,through::flags,source::user
 - belongs_to :order
 - belongs_to :profit
 - belongs_to :prefecture
@@ -204,9 +235,9 @@ Things you may want to cover:
 |seller_id|reference|null:false,foreign_key:ture|
 
 ### Association
-- has_many :rate_counts
 - belongs_to :user
 - belongs_to :item
+
 
 ## fisrt_categoriesテーブル
 
@@ -291,7 +322,6 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|id|||
 |brand_id|reference|foreign_key:ture|
 |first_category_id|reference|foreign_key:ture|
 
@@ -341,4 +371,3 @@ Things you may want to cover:
 
 ### Association
 - has_many :items
-- has_many :messages


### PR DESCRIPTION
Reverts [oohashi7/freemarket_sample_68f#32

what
ER図の写真を添付できていなかったので添付。
![freemarket_sample_68f](https://user-images.githubusercontent.com/59810076/74706645-db6b5480-525a-11ea-9e48-127e08db6b02.png)

why
ER図がないとわかりにくいため。

