### PR TITLE
リロードしなくてもancestryが反映する、マイグレートファイルから余計な記述を消す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require rails-ujs
 //= require jquery
 //= require activestorage
-//= require turbolinks
 //= require_tree .
 //= require jquery 
 //= require jquery_ujs 

--- a/app/models/category_size.rb
+++ b/app/models/category_size.rb
@@ -1,2 +1,0 @@
-class CategorySize < ApplicationRecord
-end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,16 +12,6 @@ class Item < ApplicationRecord
     belongs_to_active_hash :prefecture
     belongs_to_active_hash :deriver_date
     belongs_to_active_hash :soldout_or_exhibiting
-  # has_many :likes
-  # has_many :message_users,through::messages,source::user
-  # has_many :like_users,through::likes,source::user
-  # belongs_to :profit
-  # belongs_to :prefecture
-  # belongs_to :brand
-  # belongs_to :condition
-  # belongs_to :delivery_charge
-  # belongs_to :delivery_date
-  # belongs_to :order_status
 
   validates :name,:price,:description,:deriver_charge,:deriver_date,:category_id,:condition_id,:prefecture_id, presence: true
 

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -1,6 +1,0 @@
-class Size < ApplicationRecord
-  has_many :products
-  has_many :category_sizes
-  has_many :categories, through: :category_sizes
-  has_ancestry
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -8,16 +6,8 @@ class User < ApplicationRecord
   has_many :cards
   has_one :street_address 
   accepts_nested_attributes_for :street_address,allow_destroy: true
-
-  # has_many   :orders
-  # has_many   :profits
-  # has_many   :points
   has_many   :messages
-  # has_many   :likes
-  # has_many   :message_items,through::messages,source::item
-  # has_many   :like_items,through::likes,source::item
-  # has_many   :flag_items,through::flags,source::item
-  # belongs_to :rate
+
   validates  :nickname,:birth_year,:birth_month,:birth_day,presence: true
    # メールの正規表現
   # validates :email, presence: true, length: { maximum: 255 },uniqueness: true

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -14,8 +14,6 @@
           カテゴリ
         =link_to "#" , class:"header__box__navi__left__brand" do
           ブランド
-        =link_to "" , class:"header__box__navi__left__secondzone" do
-          裏ルート
       .header__box__navi__right
         - if user_signed_in?
           = link_to user_path(current_user), class: "header__box__navi__right__new" do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = yield

--- a/db/migrate/20200213023027_create_items.rb
+++ b/db/migrate/20200213023027_create_items.rb
@@ -11,17 +11,6 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer :prefecture_id,	  null:false
       t.integer :deriver_date_id,	  null:false
       t.integer :soldout_or_exhibiting_id, default: 1
-      # t.references	:condition,	foreign_key:true
-      # t.reference	category_id	foreign_key:true
-      # t.reference	brand_id	foreign_key:true
-      # t.reference	size_id	foreign_key:true
-      # delivery_charge_id	reference	foreign_key:true
-      # address_id	reference	foreign_key:true
-      # delivery_dates_id	reference	foreign_key:true
-      # order_status_id	reference	foreign_key:true
-      t.string :name
-      t.integer :price
-      
       t.timestamps
     end
   end

--- a/db/migrate/20200214114804_add_column_to_users.rb
+++ b/db/migrate/20200214114804_add_column_to_users.rb
@@ -4,13 +4,9 @@ class AddColumnToUsers < ActiveRecord::Migration[5.2]
     add_column :users, :first_name, :string ,           null:false
     add_column :users, :first_name_kana, :string ,      null:false
     add_column :users, :last_name, :string ,            null:false
-    add_column :users, :last_name_kana, :string ,       null:false
-    # add_column :users, :confirmation_password,:string , null:false        
+    add_column :users, :last_name_kana, :string ,       null:false     
     add_column :users, :birth_year, :integer ,          null:false
     add_column :users, :birth_month, :integer ,         null:false
     add_column :users, :birth_day, :integer ,           null:false
-    # add_column :users, :user_icon , :text
-    # add_column :users, :point_amount , :integer
-    # add_column :users, :profit_amount,  :integer 
   end
 end

--- a/db/migrate/20200218110407_create_street_addresses.rb
+++ b/db/migrate/20200218110407_create_street_addresses.rb
@@ -12,7 +12,6 @@ class CreateStreetAddresses < ActiveRecord::Migration[5.2]
       t.integer      :telephone
       t.integer      :prefecture_id,    null:false
       t.references :user, foreign_key: true
-      # add_index :stree_address ,:user_id
       t.timestamps
     end
   end

--- a/db/migrate/20200219102659_create_orders.rb
+++ b/db/migrate/20200219102659_create_orders.rb
@@ -3,7 +3,6 @@ class CreateOrders < ActiveRecord::Migration[5.2]
     create_table :orders do |t|
       t.integer :user_id
       t.integer :item_id
-
       t.timestamps
     end
   end

--- a/db/migrate/20200221083855_create_cards.rb
+++ b/db/migrate/20200221083855_create_cards.rb
@@ -7,7 +7,6 @@ class CreateCards < ActiveRecord::Migration[5.2]
       t.integer :number
       t.integer :cvc
       t.string :customer_id
-      
       t.timestamps
     end
   end

--- a/db/migrate/20200228051937_create_sizes.rb
+++ b/db/migrate/20200228051937_create_sizes.rb
@@ -1,8 +1,0 @@
-class CreateSizes < ActiveRecord::Migration[5.2]
-  def change
-    create_table :sizes do |t|
-      t.string  :size
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20200228052140_create_category_sizes.rb
+++ b/db/migrate/20200228052140_create_category_sizes.rb
@@ -1,8 +1,0 @@
-class CreateCategorySizes < ActiveRecord::Migration[5.2]
-  def change
-    create_table :category_sizes do |t|
-      t.references  :category
-      t.references  :size
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_02_26_115740) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -28,13 +27,6 @@ ActiveRecord::Schema.define(version: 2020_02_26_115740) do
     t.string "name"
     t.string "ancestry"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
-  end
-
-  create_table "category_sizes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "category_id"
-    t.bigint "size_id"
-    t.index ["category_id"], name: "index_category_sizes_on_category_id"
-    t.index ["size_id"], name: "index_category_sizes_on_size_id"
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -57,9 +49,8 @@ ActiveRecord::Schema.define(version: 2020_02_26_115740) do
     t.integer "soldout_or_exhibiting_id", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
     t.integer "category_id"
-
+    t.bigint "user_id"
     t.bigint "order_id"
     t.index ["order_id"], name: "index_items_on_order_id"
     t.index ["user_id"], name: "index_items_on_user_id"
@@ -76,12 +67,6 @@ ActiveRecord::Schema.define(version: 2020_02_26_115740) do
   create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "item_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "sizes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "size"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# what
・出品画面で、今まではリロードしないと「カテゴリー」部分に
　acentryが反映されず、親要素しか選択できなかったのを修正しました。
　ホーム画面から飛んだだけで、acentryが反映されます。
・マイグレーションファイルなどの余計な記述を削除しました。

# why
・より実際のサイトに近づけるため