### PR TITLE
tubolinkがカテゴリーの選択部分だけ効かないように設定しました

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load', function() { 
   function appendOption(category){
     var html = `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
     return html;


### PR DESCRIPTION
# what
今まではホーム画面から出品画面に移動しただけではancestryが反映されず
リロードしないと反映されませんでした。
そこでcategory.jsのtubolinkがカテゴリーの選択部分だけ効かないように設定しました。

#why
つどつどリロードしなくてよくするため。